### PR TITLE
Fix: secret may leak from container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,6 +30,7 @@ yarn-error.log*
 .env.development.local
 .env.test
 .env.test.local
+.env.production
 .env.production.local
 
 # vercel

--- a/dockerfile
+++ b/dockerfile
@@ -9,7 +9,9 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NODE_ENV production
-RUN npm run build
+# without local suffix, next will copy the env file to standalone output
+# which might leak secret
+RUN --mount=type=secret,id=env,dst=/app/.env.production.local npm run build
 
 FROM node:16-alpine AS runner
 WORKDIR /app


### PR DESCRIPTION
Next.js will copy environment file without `.local` suffix, which may expose secrets in environment files